### PR TITLE
utils.py & retrievalandgenrator updated

### DIFF
--- a/QASystem/retrievalandgenrator.py
+++ b/QASystem/retrievalandgenrator.py
@@ -9,6 +9,10 @@ from QASystem.utility import pinecone_config
 import os
 from dotenv import load_dotenv
 
+load_dotenv()
+HF_TOKEN = os.environ.get('HF_TOKEN')
+os.environ['HF_TOKEN'] = HF_TOKEN
+
 prompt_template = """Answer the following query based on the provided context. If the context does
                      not include an answer, reply with 'I don't know'.\n
                      Query: {{query}}
@@ -25,7 +29,7 @@ def get_result(query):
     query_pipeline.add_component("text_embedder", SentenceTransformersTextEmbedder())
     query_pipeline.add_component("retriever", PineconeEmbeddingRetriever(document_store=pinecone_config()))
     query_pipeline.add_component("prompt_builder", PromptBuilder(template=prompt_template))
-    query_pipeline.add_component("llm", HuggingFaceTGIGenerator(model="mistralai/Mistral-7B-v0.1", token=Secret.from_token("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")))
+    query_pipeline.add_component("llm", HuggingFaceTGIGenerator(model="mistralai/Mistral-7B-v0.1", token=Secret.from_token(os.environ['HF_TOKEN'])))
 
     query_pipeline.connect("text_embedder.embedding", "retriever.query_embedding")
     query_pipeline.connect("retriever.documents", "prompt_builder.documents")

--- a/QASystem/utility.py
+++ b/QASystem/utility.py
@@ -1,4 +1,3 @@
-
 from haystack_integrations.document_stores.pinecone import PineconeDocumentStore
 import os
 from dotenv import load_dotenv
@@ -6,15 +5,27 @@ from dotenv import load_dotenv
 load_dotenv()
 PINECONE_API_KEY = os.getenv("PINECONE_API_KEY")
 os.environ['PINECONE_API_KEY'] = PINECONE_API_KEY
-    
+
 print("Import Successfully")
 
+# Wrapper class for the API key
+
+
+class ApiKeyWrapper:
+    def __init__(self, api_key):
+        self.api_key = api_key
+
+    def resolve_value(self):
+        return self.api_key
+
+
 def pinecone_config():
-    #configuring pinecone database
+    wrapped_api_key = ApiKeyWrapper(os.environ['PINECONE_API_KEY'])
+
     document_store = PineconeDocumentStore(
-            environment="gcp-starter",
-            index="default",
-            namespace="default",
-            dimension=768
-        )
+        api_key=wrapped_api_key,
+        index="default",
+        namespace="default",
+        dimension=768
+    )
     return document_store


### PR DESCRIPTION
- `utils.py:` PineconeDocumentStore() function updated according to new docs.
- `trievalandgenrator.py:` api-token was exposed, fixed with env variables